### PR TITLE
A function to factor out site-based delays and rates from baseline-based slopes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,9 +29,15 @@ var/
 *.manifest
 *.spec
 
+# PyBuilder
+target/
+
 # Installer logs
 pip-log.txt
 pip-delete-this-directory.txt
+
+# Jupyter Notebook Checkpoints
+.ipynb_checkpoints/
 
 # Unit test / coverage reports
 htmlcov/
@@ -52,6 +58,7 @@ coverage.xml
 
 # Sphinx documentation
 docs/_build/
+html/
 
-# PyBuilder
-target/
+# Emacs backups
+*~

--- a/doc/Doxyfile
+++ b/doc/Doxyfile
@@ -1,0 +1,329 @@
+# Doxyfile 1.8.13
+
+#---------------------------------------------------------------------------
+# Project related configuration options
+#---------------------------------------------------------------------------
+DOXYFILE_ENCODING      = UTF-8
+PROJECT_NAME           = "eat"
+PROJECT_NUMBER         =
+PROJECT_BRIEF          =
+PROJECT_LOGO           =
+OUTPUT_DIRECTORY       =
+CREATE_SUBDIRS         = NO
+ALLOW_UNICODE_NAMES    = NO
+OUTPUT_LANGUAGE        = English
+BRIEF_MEMBER_DESC      = YES
+REPEAT_BRIEF           = YES
+ABBREVIATE_BRIEF       = "The $name class" \
+                         "The $name widget" \
+                         "The $name file" \
+                         is \
+                         provides \
+                         specifies \
+                         contains \
+                         represents \
+                         a \
+                         an \
+                         the
+ALWAYS_DETAILED_SEC    = NO
+INLINE_INHERITED_MEMB  = NO
+FULL_PATH_NAMES        = NO
+STRIP_FROM_PATH        =
+STRIP_FROM_INC_PATH    =
+SHORT_NAMES            = NO
+JAVADOC_AUTOBRIEF      = YES
+QT_AUTOBRIEF           = NO
+MULTILINE_CPP_IS_BRIEF = NO
+INHERIT_DOCS           = YES
+SEPARATE_MEMBER_PAGES  = NO
+TAB_SIZE               = 4
+ALIASES                =
+TCL_SUBST              =
+OPTIMIZE_OUTPUT_FOR_C  = NO
+OPTIMIZE_OUTPUT_JAVA   = YES
+OPTIMIZE_FOR_FORTRAN   = NO
+OPTIMIZE_OUTPUT_VHDL   = NO
+EXTENSION_MAPPING      =
+MARKDOWN_SUPPORT       = YES
+TOC_INCLUDE_HEADINGS   = 0
+AUTOLINK_SUPPORT       = YES
+BUILTIN_STL_SUPPORT    = NO
+CPP_CLI_SUPPORT        = NO
+SIP_SUPPORT            = NO
+IDL_PROPERTY_SUPPORT   = YES
+DISTRIBUTE_GROUP_DOC   = NO
+GROUP_NESTED_COMPOUNDS = NO
+SUBGROUPING            = YES
+INLINE_GROUPED_CLASSES = NO
+INLINE_SIMPLE_STRUCTS  = NO
+TYPEDEF_HIDES_STRUCT   = NO
+LOOKUP_CACHE_SIZE      = 0
+#---------------------------------------------------------------------------
+# Build related configuration options
+#---------------------------------------------------------------------------
+EXTRACT_ALL            = YES
+EXTRACT_PRIVATE        = NO
+EXTRACT_PACKAGE        = NO
+EXTRACT_STATIC         = NO
+EXTRACT_LOCAL_CLASSES  = YES
+EXTRACT_LOCAL_METHODS  = NO
+EXTRACT_ANON_NSPACES   = NO
+HIDE_UNDOC_MEMBERS     = NO
+HIDE_UNDOC_CLASSES     = NO
+HIDE_FRIEND_COMPOUNDS  = NO
+HIDE_IN_BODY_DOCS      = NO
+INTERNAL_DOCS          = NO
+CASE_SENSE_NAMES       = NO
+HIDE_SCOPE_NAMES       = NO
+HIDE_COMPOUND_REFERENCE= NO
+SHOW_INCLUDE_FILES     = YES
+SHOW_GROUPED_MEMB_INC  = NO
+FORCE_LOCAL_INCLUDES   = NO
+INLINE_INFO            = YES
+SORT_MEMBER_DOCS       = YES
+SORT_BRIEF_DOCS        = NO
+SORT_MEMBERS_CTORS_1ST = NO
+SORT_GROUP_NAMES       = NO
+SORT_BY_SCOPE_NAME     = NO
+STRICT_PROTO_MATCHING  = NO
+GENERATE_TODOLIST      = YES
+GENERATE_TESTLIST      = YES
+GENERATE_BUGLIST       = YES
+GENERATE_DEPRECATEDLIST= YES
+ENABLED_SECTIONS       =
+MAX_INITIALIZER_LINES  = 30
+SHOW_USED_FILES        = YES
+SHOW_FILES             = YES
+SHOW_NAMESPACES        = YES
+FILE_VERSION_FILTER    =
+LAYOUT_FILE            =
+CITE_BIB_FILES         =
+#---------------------------------------------------------------------------
+# Configuration options related to warning and progress messages
+#---------------------------------------------------------------------------
+QUIET                  = NO
+WARNINGS               = YES
+WARN_IF_UNDOCUMENTED   = YES
+WARN_IF_DOC_ERROR      = YES
+WARN_NO_PARAMDOC       = NO
+WARN_AS_ERROR          = NO
+WARN_FORMAT            = "$file:$line: $text"
+WARN_LOGFILE           =
+#---------------------------------------------------------------------------
+# Configuration options related to the input files
+#---------------------------------------------------------------------------
+INPUT                  = ../eat
+INPUT_ENCODING         = UTF-8
+FILE_PATTERNS          = *.dox *.py
+RECURSIVE              = YES
+EXCLUDE                =
+EXCLUDE_SYMLINKS       = NO
+EXCLUDE_PATTERNS       =
+EXCLUDE_SYMBOLS        =
+EXAMPLE_PATH           =
+EXAMPLE_PATTERNS       = *
+EXAMPLE_RECURSIVE      = NO
+IMAGE_PATH             =
+INPUT_FILTER           =
+FILTER_PATTERNS        = *.py=./py_filter
+FILTER_SOURCE_FILES    = NO
+FILTER_SOURCE_PATTERNS =
+USE_MDFILE_AS_MAINPAGE =
+#---------------------------------------------------------------------------
+# Configuration options related to source browsing
+#---------------------------------------------------------------------------
+SOURCE_BROWSER         = YES
+INLINE_SOURCES         = NO
+STRIP_CODE_COMMENTS    = NO
+REFERENCED_BY_RELATION = NO
+REFERENCES_RELATION    = NO
+REFERENCES_LINK_SOURCE = YES
+SOURCE_TOOLTIPS        = YES
+USE_HTAGS              = NO
+VERBATIM_HEADERS       = YES
+#---------------------------------------------------------------------------
+# Configuration options related to the alphabetical class index
+#---------------------------------------------------------------------------
+ALPHABETICAL_INDEX     = YES
+COLS_IN_ALPHA_INDEX    = 5
+IGNORE_PREFIX          =
+#---------------------------------------------------------------------------
+# Configuration options related to the HTML output
+#---------------------------------------------------------------------------
+GENERATE_HTML          = YES
+HTML_OUTPUT            = html
+HTML_FILE_EXTENSION    = .html
+HTML_HEADER            =
+HTML_FOOTER            =
+HTML_STYLESHEET        =
+HTML_EXTRA_STYLESHEET  =
+HTML_EXTRA_FILES       =
+HTML_COLORSTYLE_HUE    = 220
+HTML_COLORSTYLE_SAT    = 100
+HTML_COLORSTYLE_GAMMA  = 80
+HTML_TIMESTAMP         = NO
+HTML_DYNAMIC_SECTIONS  = NO
+HTML_INDEX_NUM_ENTRIES = 100
+GENERATE_DOCSET        = NO
+DOCSET_FEEDNAME        = "Doxygen generated docs"
+DOCSET_BUNDLE_ID       = org.doxygen.Project
+DOCSET_PUBLISHER_ID    = org.doxygen.Publisher
+DOCSET_PUBLISHER_NAME  = Publisher
+GENERATE_HTMLHELP      = NO
+CHM_FILE               =
+HHC_LOCATION           =
+GENERATE_CHI           = NO
+CHM_INDEX_ENCODING     =
+BINARY_TOC             = NO
+TOC_EXPAND             = NO
+GENERATE_QHP           = NO
+QCH_FILE               =
+QHP_NAMESPACE          = org.doxygen.Project
+QHP_VIRTUAL_FOLDER     = doc
+QHP_CUST_FILTER_NAME   =
+QHP_CUST_FILTER_ATTRS  =
+QHP_SECT_FILTER_ATTRS  =
+QHG_LOCATION           =
+GENERATE_ECLIPSEHELP   = NO
+ECLIPSE_DOC_ID         = org.doxygen.Project
+DISABLE_INDEX          = NO
+GENERATE_TREEVIEW      = YES
+ENUM_VALUES_PER_LINE   = 4
+TREEVIEW_WIDTH         = 250
+EXT_LINKS_IN_WINDOW    = NO
+FORMULA_FONTSIZE       = 10
+FORMULA_TRANSPARENT    = YES
+USE_MATHJAX            = YES
+MATHJAX_FORMAT         = HTML-CSS
+MATHJAX_RELPATH        = https://cdn.mathjax.org/mathjax/latest
+MATHJAX_EXTENSIONS     =
+MATHJAX_CODEFILE       =
+SEARCHENGINE           = YES
+SERVER_BASED_SEARCH    = NO
+EXTERNAL_SEARCH        = NO
+SEARCHENGINE_URL       =
+SEARCHDATA_FILE        = searchdata.xml
+EXTERNAL_SEARCH_ID     =
+EXTRA_SEARCH_MAPPINGS  =
+#---------------------------------------------------------------------------
+# Configuration options related to the LaTeX output
+#---------------------------------------------------------------------------
+GENERATE_LATEX         = NO
+LATEX_OUTPUT           = latex
+LATEX_CMD_NAME         = latex
+MAKEINDEX_CMD_NAME     = makeindex
+COMPACT_LATEX          = NO
+PAPER_TYPE             = a4
+EXTRA_PACKAGES         =
+LATEX_HEADER           =
+LATEX_FOOTER           =
+LATEX_EXTRA_STYLESHEET =
+LATEX_EXTRA_FILES      =
+PDF_HYPERLINKS         = YES
+USE_PDFLATEX           = YES
+LATEX_BATCHMODE        = NO
+LATEX_HIDE_INDICES     = NO
+LATEX_SOURCE_CODE      = NO
+LATEX_BIB_STYLE        = plain
+LATEX_TIMESTAMP        = NO
+#---------------------------------------------------------------------------
+# Configuration options related to the RTF output
+#---------------------------------------------------------------------------
+GENERATE_RTF           = NO
+RTF_OUTPUT             = rtf
+COMPACT_RTF            = NO
+RTF_HYPERLINKS         = NO
+RTF_STYLESHEET_FILE    =
+RTF_EXTENSIONS_FILE    =
+RTF_SOURCE_CODE        = NO
+#---------------------------------------------------------------------------
+# Configuration options related to the man page output
+#---------------------------------------------------------------------------
+GENERATE_MAN           = NO
+MAN_OUTPUT             = man
+MAN_EXTENSION          = .3
+MAN_SUBDIR             =
+MAN_LINKS              = NO
+#---------------------------------------------------------------------------
+# Configuration options related to the XML output
+#---------------------------------------------------------------------------
+GENERATE_XML           = NO
+XML_OUTPUT             = xml
+XML_PROGRAMLISTING     = YES
+#---------------------------------------------------------------------------
+# Configuration options related to the DOCBOOK output
+#---------------------------------------------------------------------------
+GENERATE_DOCBOOK       = NO
+DOCBOOK_OUTPUT         = docbook
+DOCBOOK_PROGRAMLISTING = NO
+#---------------------------------------------------------------------------
+# Configuration options for the AutoGen Definitions output
+#---------------------------------------------------------------------------
+GENERATE_AUTOGEN_DEF   = NO
+#---------------------------------------------------------------------------
+# Configuration options related to the Perl module output
+#---------------------------------------------------------------------------
+GENERATE_PERLMOD       = NO
+PERLMOD_LATEX          = NO
+PERLMOD_PRETTY         = YES
+PERLMOD_MAKEVAR_PREFIX =
+#---------------------------------------------------------------------------
+# Configuration options related to the preprocessor
+#---------------------------------------------------------------------------
+ENABLE_PREPROCESSING   = YES
+MACRO_EXPANSION        = NO
+EXPAND_ONLY_PREDEF     = NO
+SEARCH_INCLUDES        = YES
+INCLUDE_PATH           =
+INCLUDE_FILE_PATTERNS  =
+PREDEFINED             =
+EXPAND_AS_DEFINED      =
+SKIP_FUNCTION_MACROS   = YES
+#---------------------------------------------------------------------------
+# Configuration options related to external references
+#---------------------------------------------------------------------------
+TAGFILES               =
+GENERATE_TAGFILE       =
+ALLEXTERNALS           = NO
+EXTERNAL_GROUPS        = YES
+EXTERNAL_PAGES         = YES
+PERL_PATH              = /usr/bin/perl
+#---------------------------------------------------------------------------
+# Configuration options related to the dot tool
+#---------------------------------------------------------------------------
+CLASS_DIAGRAMS         = YES
+MSCGEN_PATH            =
+DIA_PATH               =
+HIDE_UNDOC_RELATIONS   = YES
+HAVE_DOT               = YES
+DOT_NUM_THREADS        = 0
+DOT_FONTNAME           = Helvetica
+DOT_FONTSIZE           = 10
+DOT_FONTPATH           =
+CLASS_GRAPH            = YES
+COLLABORATION_GRAPH    = YES
+GROUP_GRAPHS           = YES
+UML_LOOK               = NO
+UML_LIMIT_NUM_FIELDS   = 10
+TEMPLATE_RELATIONS     = NO
+INCLUDE_GRAPH          = YES
+INCLUDED_BY_GRAPH      = YES
+CALL_GRAPH             = YES
+CALLER_GRAPH           = YES
+GRAPHICAL_HIERARCHY    = YES
+DIRECTORY_GRAPH        = YES
+DOT_IMAGE_FORMAT       = png
+INTERACTIVE_SVG        = NO
+DOT_PATH               =
+DOTFILE_DIRS           =
+MSCFILE_DIRS           =
+DIAFILE_DIRS           =
+PLANTUML_JAR_PATH      =
+PLANTUML_CFG_FILE      =
+PLANTUML_INCLUDE_PATH  =
+DOT_GRAPH_MAX_NODES    = 50
+MAX_DOT_GRAPH_DEPTH    = 0
+DOT_TRANSPARENT        = NO
+DOT_MULTI_TARGETS      = NO
+GENERATE_LEGEND        = YES
+DOT_CLEANUP            = YES

--- a/doc/py_filter
+++ b/doc/py_filter
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+python3 -m doxypypy.doxypypy -a -c $1

--- a/eat/factor.py
+++ b/eat/factor.py
@@ -1,0 +1,95 @@
+from __future__ import division
+from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import absolute_import
+from future import standard_library
+standard_library.install_aliases()
+
+import math
+import numpy as np
+from scipy.optimize import least_squares
+
+def factor(bb, initial_guess=None,
+           regularizer='Tikhonov', weight=1.0):
+    """
+    Factor out site-based delay and rate from baseline-based slopes
+
+    The linear drift (slopes) of phase with frequency and time are
+    usually interpreted as delays and rates, and are removed from the
+    VLBI data in fringe fitting.  Let n be the number of feeds.  There
+    are n (n-1) such slopes in total.  Using all of them, such as
+    currently done in HOPS, breaks the closure relationships in
+    general.
+
+    Global fringe solution takes into account the assumption that
+    delays and rates are site-based.  The main advantage is that it
+    preserves the closure relationships.  Even better, "one person's
+    noise is another person's signal", the remaining slopes after
+    global fringe fit actually contain information about the source
+    images.  Being able to factor out these site-based "noise" from
+    the baseline-based "data", therefore, is essential for developing
+    new high-order image reconstruction methods.
+
+    We implement here a very general approach to factor out site-based
+    information from baseline-based information.  Let obs[] be the
+    observational data and sol[] be the solution array, the simplest
+    error function is
+
+        err[ref, rem] = obs[ref, rem] - (sol[ref] - sol[rem])
+
+    so that the minimization is performed over
+
+        chi^2 = sum_baselines err[ref, rem]^2 / sigma[ref, rem]^2
+
+    However, it is clear that sol[] is not uniquely determined because
+    err[ref, rem] is invariant to a global constant offset to sol[].
+    The simplest fix is to add the regularizer
+
+        w sum_feeds sol^2
+
+    This is equivalent to using the Tikhonov regularizer with Tikhonov
+    matrix w I.
+
+    Args:
+        bb:               A numpy structured array or pandas dataframe of
+                          baseline-based input data
+        initial_guess:    Initial conditions of the minimizer
+        regularizer:      Name of the regularizer
+        weight:           Weight of the regularizer
+
+    Returns:
+        A dictionary of site-based data being factored out
+
+    """
+    feeds = set(bb['ref']) | set(bb['rem'])
+    map   = {f: i for i, f in enumerate(feeds)}
+
+    ref = np.array([map[f] for f in bb['ref']])
+    rem = np.array([map[f] for f in bb['rem']])
+    obs = np.array(                 bb['val'] )
+    def err(sol): # closure (as in functional languages) on ref, rem, and obs
+        if regularizer is None:
+            return obs - (sol[ref] - sol[rem])
+        else:
+            reg = sol if regularizer == 'Tikhonov' else np.mean(sol)
+            return np.append(obs - (sol[ref] - sol[rem]),
+                             math.sqrt(weight) * reg)
+
+    if initial_guess is None:
+        initial_guess = np.zeros(len(feeds))
+    elif len(initial_guess) != len(feeds):
+        raise IndexError("Lengths of initial_guess ({}) and feeds ({}) "
+                         "do not match".format(len(initial_guess),
+                                               len(feeds)))
+
+    sol = least_squares(err, initial_guess)
+    if sol.success:
+        if regularizer is None:
+            v = sol.x - np.mean(sol.x)
+        elif regularizer == 'Tikhonov':
+            v = sol.x * (1.0 + weight/len(feeds))
+        else: # regularizer == 'mean'
+            v = sol.x
+        return {f: v[i] for i, f in enumerate(feeds)}
+    else:
+        return None

--- a/eat/tests/__init__.py
+++ b/eat/tests/__init__.py
@@ -6,4 +6,4 @@
 .. moduleauthor:: Lindy Blackburn (lindylam@gmail.com)
 
 """
-from .factor import *
+from . import *

--- a/eat/tests/test_factor.py
+++ b/eat/tests/test_factor.py
@@ -1,0 +1,17 @@
+import pandas as pd
+from ..factor import *
+
+def test_factor():
+    """
+    Test if factor() successfully factors out site-based delay and rate
+    """
+    bb = [('a','b',0), ('b','c',0), ('c','d',0), ('d','e',0), ('e','a',0),
+          ('a','c',0), ('b','d',0), ('c','e',0), ('d','a',0), ('e','b',0)]
+
+    x  = np.array(bb, dtype=[('ref', 'U3'),('rem', 'U2'), ('val', 'f16')])
+    sb = factor(x)
+    assert sb is not None
+
+    y  = pd.DataFrame(x)
+    sb = factor(y)
+    assert sb is not None

--- a/examples/factor.ipynb
+++ b/examples/factor.ipynb
@@ -1,0 +1,186 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Sample Jupyter Notebook for Using `eat.factor()`"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Load all the useful python modules\n",
+    "\n",
+    "The `eat` module is actively developed.  It is installed in the development mode by `cd eat && pip install -e .` (note the `-e` flag).  Together with the the `autoreload` jupyter extension, we have a smooth development workflow that does not require continuous module reinstallation."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%load_ext autoreload\n",
+    "%autoreload 2\n",
+    "\n",
+    "import pandas as pd\n",
+    "import numpy  as np\n",
+    "import eat"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Randomly generate a dictionary of zero-mean site-based rates/delays"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "a -0.022633793981\n",
+      "b 0.300877104612\n",
+      "c 0.0712440895528\n",
+      "d -0.300592350357\n",
+      "e -0.0488950498268\n"
+     ]
+    }
+   ],
+   "source": [
+    "sites = \"abcde\"\n",
+    "\n",
+    "r  = 2 * np.random.rand(len(sites)) - 1\n",
+    "r -= np.mean(r)\n",
+    "sb = {s:r[i] for i, s in enumerate(sites)}\n",
+    "for s in sites:\n",
+    "    print(s, sb[s])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Generate baseline-based rates/delays using `sb`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[('a', 'b', -0.3235109) ('a', 'c', -0.093877884) ('a', 'd',  0.27795856)\n",
+      " ('a', 'e',  0.026261256) ('b', 'c',  0.22963302) ('b', 'd',  0.60146945)\n",
+      " ('b', 'e',  0.34977215) ('c', 'd',  0.37183644) ('c', 'e',  0.12013914)\n",
+      " ('d', 'e', -0.2516973)]\n"
+     ]
+    }
+   ],
+   "source": [
+    "bb = np.array([(ref, rem, sb[ref] - sb[rem]) for ref in sites for rem in sites if rem > ref],\n",
+    "              dtype=[('ref', 'U3'), ('rem', 'U2'), ('val', 'f16')])\n",
+    "print(bb)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Use `eat.factor()` to factor out site-based delays/rates from baseline-based delays/rates"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "a -0.022633793981\n",
+      "b 0.300877104612\n",
+      "c 0.0712440895528\n",
+      "d -0.300592350357\n",
+      "e -0.0488950498268\n"
+     ]
+    }
+   ],
+   "source": [
+    "sol = eat.factor(bb, regularizer=None, weight=10.0)\n",
+    "for s in sites:\n",
+    "    print(s, sol[s])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The solution is in general different from the original rates/delays by a constant."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "a 5.08219768353e-21\n",
+      "b 0.0\n",
+      "c 0.0\n",
+      "d 0.0\n",
+      "e -3.38813178902e-21\n"
+     ]
+    }
+   ],
+   "source": [
+    "for s in sites:\n",
+    "    print(s, sol[s]-sb[s])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.5.3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}


### PR DESCRIPTION
Exploring the effect of different regularizers in factoring out site-based delays and rates from baseline-based slopes.  The algorithm is implemented in eat.factor().  A jupyter notebook (works for python2 and python3) is provided in "examples/factor.ipynb" using very simple synthetic data.