### PR TITLE
Fix uvfits writer bugs

### DIFF
--- a/bin/hops2uvfits.py
+++ b/bin/hops2uvfits.py
@@ -1181,10 +1181,10 @@ def save_uvfits(datastruct, fname):
     col6 = fits.Column(name='STAXOF', format='1E', unit='METERS', array=np.zeros(nsta)) #zero = no axis  offset
     col7 = fits.Column(name='POLTYA', format='1A', array=np.array(['R' for i in range(nsta)], dtype='|S1')) #RCP
     col8 = fits.Column(name='POLAA', format='1E', unit='DEGREES', array=np.zeros(nsta)) #feed orientation A
-    col9 = fits.Column(name='POLCALA', format='2E', array=np.zeros((nsta,2))) #zero = no pol cal info TODO should have extra dim for nif
+    col9 = fits.Column(name='POLCALA', format='0E', array=np.zeros((nsta,0))) #no pol cal info (NOPCAL=0); use format='%dE'%(2*nchan) if adding D-terms
     col10 = fits.Column(name='POLTYB', format='1A', array=np.array(['L' for i in range(nsta)], dtype='|S1')) #LCP
     col11 = fits.Column(name='POLAB', format='1E', unit='DEGREES', array=90*np.ones(nsta)) #feed orientation A
-    col12 = fits.Column(name='POLCALB', format='2E', array=np.zeros((nsta,2))) #zero = no pol cal info
+    col12 = fits.Column(name='POLCALB', format='0E', array=np.zeros((nsta,0))) #no pol cal info (NOPCAL=0)
 
     # create table
     tbhdu = fits.BinTableHDU.from_columns(fits.ColDefs([col1,col2,col3,col4,col5,col6,col7,col8,col9,col10,col11,col12]), name='AIPS AN')
@@ -1216,7 +1216,8 @@ def save_uvfits(datastruct, fname):
     head['DEGPDY'] = RDATE_DEGPERDY
     head['UT1UTC'] = rdate_offset_out   #difference between UT1 and UTC ?
     head['DATUTC'] = 0.e0
-    head['TIMESYS'] = 'UTC'
+    head['TIMSYS'] = 'UTC'  # AIPS Memo 117 canonical spelling
+    head['TIMESYS'] = 'UTC' # variant spelling used by some readers
 
     head['FREQ']= ref_freq
     head['POLARX'] = 0.e0

--- a/bin/hops2uvfits.py
+++ b/bin/hops2uvfits.py
@@ -1173,7 +1173,7 @@ def save_uvfits(datastruct, fname):
     #Antenna Table entries
     col1 = fits.Column(name='ANNAME', format='8A', array=antnames)
     col2 = fits.Column(name='STABXYZ', format='3D', unit='METERS', array=xyz)
-    col3= fits.Column(name='ORBPARM', format='D', array=np.zeros(0))
+    col3= fits.Column(name='ORBPARM', format='0D', array=np.zeros((nsta, 0)))
     col4 = fits.Column(name='NOSTA', format='1J', array=antnums)
 
     #TODO get the actual information for these parameters for each station

--- a/eat/io/uvfits.py
+++ b/eat/io/uvfits.py
@@ -862,10 +862,10 @@ def save_uvfits(datastruct, fname):
     col6 = fits.Column(name='STAXOF', format='1E', unit='METERS', array=np.zeros(nsta)) #zero = no axis  offset
     col7 = fits.Column(name='POLTYA', format='1A', array=np.array(['R' for i in range(nsta)], dtype='|S1')) #RCP
     col8 = fits.Column(name='POLAA', format='1E', unit='DEGREES', array=np.zeros(nsta)) #feed orientation A
-    col9 = fits.Column(name='POLCALA', format='2E', array=np.zeros((nsta,2))) #zero = no pol cal info TODO should have extra dim for nif
+    col9 = fits.Column(name='POLCALA', format='0E', array=np.zeros((nsta,0))) #no pol cal info (NOPCAL=0); use format='%dE'%(2*nchan) if adding D-terms
     col10 = fits.Column(name='POLTYB', format='1A', array=np.array(['L' for i in range(nsta)], dtype='|S1')) #LCP
     col11 = fits.Column(name='POLAB', format='1E', unit='DEGREES', array=90*np.ones(nsta)) #feed orientation A
-    col12 = fits.Column(name='POLCALB', format='2E', array=np.zeros((nsta,2))) #zero = no pol cal info
+    col12 = fits.Column(name='POLCALB', format='0E', array=np.zeros((nsta,0))) #no pol cal info (NOPCAL=0)
 
     # create table
     tbhdu = fits.BinTableHDU.from_columns(fits.ColDefs([col1,col2,col3,col4,col5,col6,col7,col8,col9,col10,col11,col12]), name='AIPS AN')
@@ -897,7 +897,8 @@ def save_uvfits(datastruct, fname):
     head['DEGPDY'] = RDATE_DEGPERDY
     head['UT1UTC'] = rdate_offset_out   #difference between UT1 and UTC ?
     head['DATUTC'] = 0.e0
-    head['TIMESYS'] = 'UTC'
+    head['TIMSYS'] = 'UTC'  # AIPS Memo 117 canonical spelling
+    head['TIMESYS'] = 'UTC' # variant spelling used by some readers
 
     head['FREQ']= ref_freq
     head['POLARX'] = 0.e0

--- a/eat/io/uvfits.py
+++ b/eat/io/uvfits.py
@@ -854,7 +854,7 @@ def save_uvfits(datastruct, fname):
     #Antenna Table entries
     col1 = fits.Column(name='ANNAME', format='8A', array=antnames)
     col2 = fits.Column(name='STABXYZ', format='3D', unit='METERS', array=xyz)
-    col3= fits.Column(name='ORBPARM', format='D', array=np.zeros(0))
+    col3= fits.Column(name='ORBPARM', format='0D', array=np.zeros((nsta, 0)))
     col4 = fits.Column(name='NOSTA', format='1J', array=antnums)
 
     #TODO get the actual information for these parameters for each station


### PR DESCRIPTION
This was uncovered when reading in the data with DIFMAP. When loading uvfits produced by HOPS we get
```
  0>observe hops_3809_M87.uvfits
  get_format: Bad format: TFORM=D
  Missing TFORM3 keyword
  Reading UV FITS file: hops_3809_M87.uvfits
  find_subarrays: No Antenna tables found.
  Error occured in command: observe
```

Looking at the uvfits standard, specifically TABLE 10 it says the type should be `D(norb)` so leaving it as a generic `D` breaks some readers. 

I also had an LLM go through the writer and look for other issues in the writer and it pointed out that we are also inconsistent in our `POLCAL` column where we set `NOPCAL = 0` which means we have zero polarization calibrations per IF, but so the table header `POLCALA` and `POLCALB` should both be `0E`. Specifically the AIPS memo states

```
In these cases, the array dimensions will appear in parentheses following the basic type, e.g.,
E(4, 32) for a two-dimensional array with 4 columns and 32 rows. In the table header, the repeat count
shall be the product of all the dimensions and the data in the array shall be laid out so that the index of
the first dimension varies fastest, followed by the second dimension, and so on.
```

Additionally, if we did include this information the AIPS memo says it should be per IF. 


Finally, I think this is a bug in the AIPS memo itself but they define both `TIMESYS` in table 8 and then in the discussion say `TIMSYS` which is also what they use in their example. Given this, it probably is reasonable to write both for the time being. 